### PR TITLE
Displays and actives a resizeable border around the configuration frame.

### DIFF
--- a/bear-factory/bear-editor/src/bf/code/config_frame.cpp
+++ b/bear-factory/bear-editor/src/bf/code/config_frame.cpp
@@ -22,7 +22,8 @@
  * \param parent The window owning this dialog.
  */
 bf::config_frame::config_frame( wxWindow* parent )
-  : wxDialog( parent, wxID_ANY, wxString(_("Configuration")) )
+  : wxDialog( parent, wxID_ANY, _("Configuration"), wxDefaultPosition, 
+             wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER )
 {
   create_controls();
   Fit();


### PR DESCRIPTION
Avec cette modification, je peux maintenant voir le chemin entier des répertoires dans la frame de configuration.
