### PR TITLE
Fix 'inaccessible within this context' error with wxWidgets 3.0

### DIFF
--- a/bear-factory/bear-editor/src/bf/code/accelerator_table.cpp
+++ b/bear-factory/bear-editor/src/bf/code/accelerator_table.cpp
@@ -99,6 +99,6 @@ void bf::accelerator_table::on_key_pressed( wxKeyEvent& event )
   if ( it != m_accelerators.end() )
     {
       wxCommandEvent command( wxEVT_COMMAND_MENU_SELECTED, it->second );
-      m_event_handler.ProcessEvent( command );
+      m_event_handler.GetEventHandler()->ProcessEvent( command );
     }
 } // accelerator_table::on_key_pressed()


### PR DESCRIPTION
`wxEvtHandler::ProcessEvent` can't be accessed from a `wxWindow` in wxWidgets 3.0 for some reason so I changed it to get the event handler and then call `ProcessEvent` from the event handler.
```
[  0%] Building CXX object bear-factory/bear-editor/src/bf/CMakeFiles/bear-editor.dir/code/accelerator_table.cpp.o
/mnt/d/Linux_home/nathan/src/plee-the-bear/bear/bear-factory/bear-editor/src/bf/code/accelerator_table.cpp: In member function ‘void bf::accelerator_table::on_key_pressed(wxKeyEvent&)’:
/mnt/d/Linux_home/nathan/src/plee-the-bear/bear/bear-factory/bear-editor/src/bf/code/accelerator_table.cpp:102:45: error: ‘virtual bool wxEvtHandler::ProcessEvent(wxEvent&)’ is inaccessible within this context
       m_event_handler.ProcessEvent( command );
                                             ^
In file included from /usr/include/wx-3.0/wx/window.h:18:0,
                 from /mnt/d/Linux_home/nathan/src/plee-the-bear/bear/bear-factory/bear-editor/src/bf/../bf/accelerator_table.hpp:19,
                 from /mnt/d/Linux_home/nathan/src/plee-the-bear/bear/bear-factory/bear-editor/src/bf/code/accelerator_table.cpp:14:
/usr/include/wx-3.0/wx/event.h:3355:18: note: declared here
     virtual bool ProcessEvent(wxEvent& event);
                  ^~~~~~~~~~~~
make[3]: *** [bear-factory/bear-editor/src/bf/CMakeFiles/bear-editor.dir/build.make:63: bear-factory/bear-editor/src/bf/CMakeFiles/bear-editor.dir/code/accelerator_table.cpp.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:1876: bear-factory/bear-editor/src/bf/CMakeFiles/bear-editor.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:1888: bear-factory/bear-editor/src/bf/CMakeFiles/bear-editor.dir/rule] Error 2
make: *** [Makefile:526: bear-editor] Error 2
```