### PR TITLE
Replace deprecated GetPropVal with GetAttribute.

### DIFF
--- a/bear-factory/bear-editor/src/bf/code/item_class_xml_parser.cpp
+++ b/bear-factory/bear-editor/src/bf/code/item_class_xml_parser.cpp
@@ -45,7 +45,7 @@ std::string bf::item_class_xml_parser::get_item_class_name
 
   wxString val;
 
-  if ( !node->GetPropVal( wxT("class"), &val ) )
+  if ( !node->GetAttribute( wxT("class"), &val ) )
     throw xml::missing_property("class");
 
   return wx_to_std_string(val);
@@ -128,24 +128,24 @@ void bf::item_class_xml_parser::read_item_properties
 {
   wxString val;
 
-  if ( !node->GetPropVal( wxT("class"), &val ) )
+  if ( !node->GetAttribute( wxT("class"), &val ) )
     throw xml::missing_property("class");
 
   item.set_class_name( wx_to_std_string(val) );
 
-  if ( !node->GetPropVal( wxT("category"), &val ) )
+  if ( !node->GetAttribute( wxT("category"), &val ) )
     throw xml::missing_property("category");
 
   item.set_category( wx_to_std_string(val) );
 
   item.set_color
-    ( wx_to_std_string(node->GetPropVal( wxT("box_color"), wxT("#00FF00") )) );
+    ( wx_to_std_string(node->GetAttribute( wxT("box_color"), wxT("#00FF00") )) );
 
   item.set_url
-    ( wx_to_std_string(node->GetPropVal( wxT("url"), wxEmptyString )) );
+    ( wx_to_std_string(node->GetAttribute( wxT("url"), wxEmptyString )) );
 
   item.set_fixable
-    ( node->GetPropVal( wxT("fixable"), wxT("true") ) == wxT("true") );
+    ( node->GetAttribute( wxT("fixable"), wxT("true") ) == wxT("true") );
 } // item_class_xml_parser::read_item_properties()
 
 /*----------------------------------------------------------------------------*/
@@ -175,7 +175,7 @@ void bf::item_class_xml_parser::read_new_default_value
 {
   wxString val;
 
-  if ( !node->GetPropVal( wxT("name"), &val ) )
+  if ( !node->GetAttribute( wxT("name"), &val ) )
     throw xml::missing_property("name");
 
   item.new_default_value
@@ -233,12 +233,12 @@ void bf::item_class_xml_parser::read_field_type
   wxString val;
   std::string name;
 
-  if ( !node->GetPropVal( wxT("name"), &val ) )
+  if ( !node->GetAttribute( wxT("name"), &val ) )
     throw xml::missing_property("name");
 
   name = wx_to_std_string(val);
 
-  if ( !node->GetPropVal( wxT("type"), &val ) )
+  if ( !node->GetAttribute( wxT("type"), &val ) )
     throw xml::missing_property("type");
 
   type_field* field;
@@ -271,9 +271,9 @@ void bf::item_class_xml_parser::read_field_type
     throw xml::bad_value( wx_to_std_string(val) );
 
   field->set_required
-    ( node->GetPropVal( wxT("required"), wxT("false") ) == wxT("true") );
+    ( node->GetAttribute( wxT("required"), wxT("false") ) == wxT("true") );
   field->set_is_list
-    ( node->GetPropVal( wxT("list"), wxT("false") ) == wxT("true") );
+    ( node->GetAttribute( wxT("list"), wxT("false") ) == wxT("true") );
 
   item.add_field(name, *field);
   delete field;
@@ -445,7 +445,7 @@ bf::item_class_xml_parser::read_after( const wxXmlNode* node ) const
 {
   wxString val;
 
-  if ( !node->GetPropVal( wxT("field"), &val ) )
+  if ( !node->GetAttribute( wxT("field"), &val ) )
     throw xml::missing_property("field");
 
   return wx_to_std_string(val);
@@ -465,7 +465,7 @@ void bf::item_class_xml_parser::read_set
       {
         wxString val;
 
-        if ( !node->GetPropVal( wxT("value"), &val ) )
+        if ( !node->GetAttribute( wxT("value"), &val ) )
           throw xml::missing_property("value");
 
         set.push_back( wx_to_std_string(val) );
@@ -577,7 +577,7 @@ bf::item_class_xml_parser::read_interval( const wxXmlNode* node ) const
   wxString val;
   std::istringstream iss;
 
-  if ( !node->GetPropVal( wxT("from"), &val ) )
+  if ( !node->GetAttribute( wxT("from"), &val ) )
     result.first = std::numeric_limits<T>::min();
   else
     {
@@ -587,7 +587,7 @@ bf::item_class_xml_parser::read_interval( const wxXmlNode* node ) const
         throw xml::bad_value( wx_to_std_string(val) );
     }
 
-  if ( !node->GetPropVal( wxT("to"), &val ) )
+  if ( !node->GetAttribute( wxT("to"), &val ) )
     result.second = std::numeric_limits<T>::max();
   else
     {

--- a/bear-factory/bear-editor/src/bf/xml/code/item_instance_node.cpp
+++ b/bear-factory/bear-editor/src/bf/xml/code/item_instance_node.cpp
@@ -50,7 +50,7 @@ bf::item_instance* bf::xml::item_instance_node::read
 
   wxString val;
 
-  if ( !node->GetPropVal( wxT("class_name"), &val ) )
+  if ( !node->GetAttribute( wxT("class_name"), &val ) )
     throw xml::missing_property( "class_name" );
 
   std::string class_name( wx_to_std_string(val) );
@@ -64,7 +64,7 @@ bf::item_instance* bf::xml::item_instance_node::read
       item->set_fixed
         ( xml::reader_tool::read_bool_opt(node, wxT("fixed"), false) );
       item->set_id
-        ( wx_to_std_string(node->GetPropVal( wxT("id"), wxEmptyString )) );
+        ( wx_to_std_string(node->GetAttribute( wxT("id"), wxEmptyString )) );
 
       load_fields( *item, node->GetChildren() );
     }

--- a/bear-factory/bear-editor/src/bf/xml/code/reader_tool.cpp
+++ b/bear-factory/bear-editor/src/bf/xml/code/reader_tool.cpp
@@ -52,7 +52,7 @@ bf::xml::reader_tool::read_int( const wxXmlNode* node, const wxString& prop )
   int result;
   wxString val;
 
-  if ( !node->GetPropVal( prop, &val ) )
+  if ( !node->GetAttribute( prop, &val ) )
     throw xml::missing_property( wx_to_std_string(prop) );
 
   std::istringstream iss( wx_to_std_string(val) );
@@ -77,7 +77,7 @@ bf::xml::reader_tool::read_uint( const wxXmlNode* node, const wxString& prop )
   unsigned int result;
   wxString val;
 
-  if ( !node->GetPropVal( prop, &val ) )
+  if ( !node->GetAttribute( prop, &val ) )
     throw xml::missing_property( wx_to_std_string(prop) );
 
   std::istringstream iss( wx_to_std_string(val) );
@@ -101,7 +101,7 @@ bf::xml::reader_tool::read_string( const wxXmlNode* node, const wxString& prop )
 
   wxString val;
 
-  if ( !node->GetPropVal( prop, &val ) )
+  if ( !node->GetAttribute( prop, &val ) )
     throw xml::missing_property( wx_to_std_string(prop) );
 
   return wx_to_std_string(val);
@@ -121,7 +121,7 @@ bf::xml::reader_tool::read_real( const wxXmlNode* node, const wxString& prop )
   double result;
   wxString val;
 
-  if ( !node->GetPropVal( prop, &val ) )
+  if ( !node->GetAttribute( prop, &val ) )
     throw xml::missing_property( wx_to_std_string(prop) );
 
   std::istringstream iss( wx_to_std_string(val) );
@@ -235,7 +235,7 @@ bool bf::xml::reader_tool::read_bool_opt
   bool result(def);
   wxString val;
 
-  if ( node->GetPropVal( prop, &val ) )
+  if ( node->GetAttribute( prop, &val ) )
     {
       if ( (val == wxT("true")) || (val == wxT("1")) )
         result = true;
@@ -262,7 +262,7 @@ bf::trinary_logic::value_type bf::xml::reader_tool::read_trinary_logic_opt
   bf::trinary_logic::value_type result(def);
   wxString val;
 
-  if ( node->GetPropVal( prop, &val ) )
+  if ( node->GetAttribute( prop, &val ) )
     {
       if ( ( val ==
              std_to_wx_string( trinary_logic::to_string

--- a/bear-factory/bear-editor/src/bf/xml/code/xml_to_value.cpp
+++ b/bear-factory/bear-editor/src/bf/xml/code/xml_to_value.cpp
@@ -190,7 +190,7 @@ void bf::xml::xml_to_value<bf::animation>::load_frame
   animation_frame frame;
   sprite spr;
 
-  if ( !node->GetPropVal( wxT("duration"), &val ) )
+  if ( !node->GetAttribute( wxT("duration"), &val ) )
     throw missing_property( "duration" );
 
   frame.set_duration
@@ -241,7 +241,7 @@ void bf::xml::xml_to_value<bf::animation_file_type>::operator()
 
   wxString path;
 
-  if ( !node->GetPropVal( wxT("path"), &path ) )
+  if ( !node->GetAttribute( wxT("path"), &path ) )
     throw missing_property("path");
 
   anim.set_path( wx_to_std_string(path), env );
@@ -316,7 +316,7 @@ void bf::xml::xml_to_value<bf::sample>::operator()
 
   wxString path;
 
-  if ( !node->GetPropVal( wxT("path"), &path ) )
+  if ( !node->GetAttribute( wxT("path"), &path ) )
     throw missing_property("path");
 
   v.set_path( wx_to_std_string(path) );
@@ -338,7 +338,7 @@ void bf::xml::xml_to_value<bf::font>::operator()
 
   wxString path;
 
-  if ( !node->GetPropVal( wxT("path"), &path ) )
+  if ( !node->GetAttribute( wxT("path"), &path ) )
     throw missing_property("path");
 
   const font default_value;

--- a/bear-factory/bear-editor/src/bf/xml/impl/xml_to_value.tpp
+++ b/bear-factory/bear-editor/src/bf/xml/impl/xml_to_value.tpp
@@ -33,7 +33,7 @@ void bf::xml::xml_to_value<Type>::operator()
   CLAW_PRECOND( node != NULL );
   wxString val;
 
-  if ( !node->GetPropVal( wxT("value"), &val ) )
+  if ( !node->GetAttribute( wxT("value"), &val ) )
     throw missing_property( "value" );
 
   const std::string std_val( wx_to_std_string(val) );

--- a/bear-factory/level-editor/src/bf/code/level_file_xml_reader.cpp
+++ b/bear-factory/level-editor/src/bf/code/level_file_xml_reader.cpp
@@ -64,8 +64,8 @@ bf::gui_level* bf::level_file_xml_reader::load_level
   width = xml::reader_tool::read_uint(node, wxT("width"));
   height = xml::reader_tool::read_uint(node, wxT("height"));
 
-  music = node->GetPropVal( wxT("music"), wxEmptyString );
-  name = node->GetPropVal( wxT("name"), wxEmptyString );
+  music = node->GetAttribute( wxT("music"), wxEmptyString );
+  name = node->GetAttribute( wxT("name"), wxEmptyString );
 
   gui_level* lvl = NULL;
 
@@ -128,10 +128,10 @@ void bf::level_file_xml_reader::load_layer
     || xml::reader_tool::read_bool_opt( node, wxT("fit_level"), false );
   tag = xml::reader_tool::read_string_opt( node, wxT("tag"), "" );
 
-  if ( !node->GetPropVal( wxT("class_name"), &val ) )
+  if ( !node->GetAttribute( wxT("class_name"), &val ) )
     throw xml::missing_property( "class_name" );
 
-  node->GetPropVal( wxT("name"), &name );
+  node->GetAttribute( wxT("name"), &name );
 
   layer& lay =
     lvl.add_layer


### PR DESCRIPTION
`GetPropVal` is deprecated since wxWidgets 2.8; the [Updating to the Latest Version of wxWidgets wiki page](https://wiki.wxwidgets.org/Updating_to_the_Latest_Version_of_wxWidgets) says to use `GetAttribute` instead:
> wxXmlProperty
>
>This is deprecated in favour of wxXmlAttribute, and code using it will only compile in a WXWIN_COMPATIBILITY_2_8 build. Usage is identical, just the name has changed. Similarly wxXmlNode::GetPropVal and wxXmlNode::GetAttribute. 