### PR TITLE
Specify namespace when using boost::placeholders.

### DIFF
--- a/bear-engine/core/src/engine/code/game_network.cpp
+++ b/bear-engine/core/src/engine/code/game_network.cpp
@@ -148,7 +148,8 @@ void bear::engine::game_network::create_service
     {
       net::server* s = new net::server(port);
       s->on_new_client.connect
-        ( boost::bind( &game_network::on_new_client, this, s, _1 ) );
+        ( boost::bind( &game_network::on_new_client, this, s,
+                       boost::placeholders::_1 ) );
       m_server[name] = s;
     }
 } // game_network::create_service()

--- a/bear-engine/core/src/engine/layer/code/transition_layer.cpp
+++ b/bear-engine/core/src/engine/layer/code/transition_layer.cpp
@@ -113,7 +113,8 @@ void bear::engine::transition_layer::render( scene_element_list& e ) const
 bool bear::engine::transition_layer::key_pressed( const input::key_info& key )
 {
   return diffuse_call
-    ( boost::bind( &transition_effect::key_pressed, _1, key) );
+    ( boost::bind( &transition_effect::key_pressed, boost::placeholders::_1,
+                   key) );
 } // transition_layer::key_pressed()
 
 /*----------------------------------------------------------------------------*/
@@ -125,7 +126,8 @@ bool bear::engine::transition_layer::key_maintained
 ( const input::key_info& key )
 {
   return diffuse_call
-    ( boost::bind( &transition_effect::key_maintained, _1, key) );
+    ( boost::bind( &transition_effect::key_maintained, boost::placeholders::_1,
+                   key) );
 } // transition_layer::key_maintained()
 
 /*----------------------------------------------------------------------------*/
@@ -136,7 +138,8 @@ bool bear::engine::transition_layer::key_maintained
 bool bear::engine::transition_layer::key_released( const input::key_info& key )
 {
   return diffuse_call
-    ( boost::bind( &transition_effect::key_released, _1, key) );
+    ( boost::bind( &transition_effect::key_released, boost::placeholders::_1,
+                   key) );
 } // transition_layer::key_released()
 
 /*----------------------------------------------------------------------------*/
@@ -147,7 +150,8 @@ bool bear::engine::transition_layer::key_released( const input::key_info& key )
 bool bear::engine::transition_layer::char_pressed( const input::key_info& key )
 {
   return diffuse_call
-    ( boost::bind( &transition_effect::char_pressed, _1, key) );
+    ( boost::bind( &transition_effect::char_pressed, boost::placeholders::_1,
+                   key) );
 } // transition_layer::char_pressed()
 
 /*----------------------------------------------------------------------------*/
@@ -160,7 +164,8 @@ bool bear::engine::transition_layer::button_pressed
 ( input::joystick::joy_code button, unsigned int joy_index )
 {
   return diffuse_call
-    ( boost::bind( &transition_effect::button_pressed, _1, button, joy_index) );
+    ( boost::bind( &transition_effect::button_pressed, boost::placeholders::_1,
+                   button, joy_index) );
 } // transition_layer::button_pressed()
 
 /*----------------------------------------------------------------------------*/
@@ -174,7 +179,8 @@ bool bear::engine::transition_layer::button_maintained
 {
   return diffuse_call
     ( boost::bind
-      ( &transition_effect::button_maintained, _1, button, joy_index) );
+      ( &transition_effect::button_maintained, boost::placeholders::_1, button,
+        joy_index) );
 } // transition_layer::button_maintained()
 
 /*----------------------------------------------------------------------------*/
@@ -188,7 +194,8 @@ bool bear::engine::transition_layer::button_released
 {
   return diffuse_call
     ( boost::bind
-      ( &transition_effect::button_released, _1, button, joy_index) );
+      ( &transition_effect::button_released, boost::placeholders::_1, button,
+        joy_index) );
 } // transition_layer::button_released()
 
 /*----------------------------------------------------------------------------*/
@@ -202,7 +209,8 @@ bool bear::engine::transition_layer::mouse_pressed
   const claw::math::coordinate_2d<unsigned int>& pos )
 {
   return diffuse_call
-    ( boost::bind( &transition_effect::mouse_pressed, _1, key, pos) );
+    ( boost::bind( &transition_effect::mouse_pressed, boost::placeholders::_1,
+                   key, pos) );
 } // transition_layer::mouse_pressed()
 
 /*----------------------------------------------------------------------------*/
@@ -216,7 +224,8 @@ bool bear::engine::transition_layer::mouse_maintained
   const claw::math::coordinate_2d<unsigned int>& pos )
 {
   return diffuse_call
-    ( boost::bind( &transition_effect::mouse_maintained, _1, key, pos) );
+    ( boost::bind( &transition_effect::mouse_maintained,
+                   boost::placeholders::_1, key, pos) );
 } // transition_layer::mouse_maintained()
 
 /*----------------------------------------------------------------------------*/
@@ -230,7 +239,8 @@ bool bear::engine::transition_layer::mouse_released
   const claw::math::coordinate_2d<unsigned int>& pos )
 {
   return diffuse_call
-    ( boost::bind( &transition_effect::mouse_released, _1, key, pos) );
+    ( boost::bind( &transition_effect::mouse_released, boost::placeholders::_1,
+                   key, pos) );
 } // transition_layer::mouse_released()
 
 /*----------------------------------------------------------------------------*/
@@ -241,7 +251,8 @@ bool bear::engine::transition_layer::mouse_released
 bool bear::engine::transition_layer::mouse_move
 ( const claw::math::coordinate_2d<unsigned int>& pos )
 {
-  return diffuse_call( boost::bind( &transition_effect::mouse_move, _1, pos) );
+  return diffuse_call( boost::bind( &transition_effect::mouse_move,
+                                    boost::placeholders::_1, pos) );
 } // transition_layer::mouse_move()
 
 /*----------------------------------------------------------------------------*/
@@ -253,7 +264,8 @@ bool bear::engine::transition_layer::finger_action
 ( const bear::input::finger_event& event )
 {
   return diffuse_call
-    ( boost::bind( &transition_effect::finger_action, _1, event) );
+    ( boost::bind( &transition_effect::finger_action, boost::placeholders::_1,
+                   event) );
 } // transition_layer::finger_action()
 
 /*----------------------------------------------------------------------------*/

--- a/bear-engine/core/src/engine/model/code/model_snapshot_tweener.cpp
+++ b/bear-engine/core/src/engine/model/code/model_snapshot_tweener.cpp
@@ -183,7 +183,8 @@ void bear::engine::model_snapshot_tweener::insert_tweener
     m_tweeners.insert
       ( claw::tween::single_tweener
         (m_placement[id].get_angle(), end.get_angle(), d,
-         boost::bind( &model_mark_placement::set_angle, &m_placement[id], _1 ),
+         boost::bind( &model_mark_placement::set_angle, &m_placement[id],
+                      boost::placeholders::_1 ),
          m_placement[id].get_angle_easing() ) );
 
   if ( m_placement[id].get_position().x != end.get_position().x )
@@ -191,7 +192,8 @@ void bear::engine::model_snapshot_tweener::insert_tweener
       ( claw::tween::single_tweener
         (m_placement[id].get_position().x, end.get_position().x, d,
          boost::bind
-         ( &model_mark_placement::set_x_position, &m_placement[id], _1 ),
+         ( &model_mark_placement::set_x_position, &m_placement[id],
+           boost::placeholders::_1 ),
          m_placement[id].get_x_position_easing() ) );
 
   if ( m_placement[id].get_position().y != end.get_position().y )
@@ -199,7 +201,8 @@ void bear::engine::model_snapshot_tweener::insert_tweener
       ( claw::tween::single_tweener
         (m_placement[id].get_position().y, end.get_position().y, d,
          boost::bind
-         ( &model_mark_placement::set_y_position, &m_placement[id], _1 ),
+         ( &model_mark_placement::set_y_position, &m_placement[id],
+           boost::placeholders::_1 ),
          m_placement[id].get_y_position_easing() ) );
 
   if ( m_placement[id].get_size().x != end.get_size().x )
@@ -207,7 +210,8 @@ void bear::engine::model_snapshot_tweener::insert_tweener
       ( claw::tween::single_tweener
         (m_placement[id].get_size().x, end.get_size().x, d,
          boost::bind
-         ( &model_mark_placement::set_width, &m_placement[id], _1 ),
+         ( &model_mark_placement::set_width, &m_placement[id],
+           boost::placeholders::_1 ),
          m_placement[id].get_width_easing() ) );
 
   if ( m_placement[id].get_size().y != end.get_size().y )
@@ -215,6 +219,7 @@ void bear::engine::model_snapshot_tweener::insert_tweener
       ( claw::tween::single_tweener
         (m_placement[id].get_size().y, end.get_size().y, d,
          boost::bind
-         ( &model_mark_placement::set_height, &m_placement[id], _1 ),
+         ( &model_mark_placement::set_height, &m_placement[id],
+           boost::placeholders::_1 ),
          m_placement[id].get_height_easing() ) );
 } // model_snapshot_tweener::insert_tweener()

--- a/bear-engine/core/src/net/code/client.cpp
+++ b/bear-engine/core/src/net/code/client.cpp
@@ -101,7 +101,7 @@ bear::net::message_handle bear::net::client::pull_message()
 void bear::net::client::connect()
 {
   const connection_task connection
-    ( boost::bind( &client::set_stream, this, _1 ),
+    ( boost::bind( &client::set_stream, this, boost::placeholders::_1 ),
       m_host, m_port, m_read_time_limit );
   //m_connection = new boost::thread(connection);
   connection();

--- a/bear-factory/model-editor/src/bf/code/model_snapshot_tweener.cpp
+++ b/bear-factory/model-editor/src/bf/code/model_snapshot_tweener.cpp
@@ -146,26 +146,28 @@ void bf::model_snapshot_tweener::insert_tweener
   m_tweeners.insert
   ( claw::tween::single_tweener
     (m.get_angle(), end.get_angle(), d,
-      boost::bind( &mark_placement::set_angle, &m, _1 ),
+      boost::bind( &mark_placement::set_angle, &m, boost::placeholders::_1 ),
       m.get_angle_easing().to_claw_easing_function() ) );
   m_tweeners.insert
   ( claw::tween::single_tweener
     ( m.get_x_position(), end.get_x_position(), d,
-      boost::bind( &mark_placement::set_x_position, &m, _1 ),
+      boost::bind( &mark_placement::set_x_position, &m,
+                   boost::placeholders::_1 ),
       m.get_x_easing().to_claw_easing_function() ) );
   m_tweeners.insert
   ( claw::tween::single_tweener
     ( m.get_y_position(), end.get_y_position(), d,
-      boost::bind( &mark_placement::set_y_position, &m, _1 ),
+      boost::bind( &mark_placement::set_y_position, &m,
+                   boost::placeholders::_1 ),
       m.get_y_easing().to_claw_easing_function() ) );
   m_tweeners.insert
   ( claw::tween::single_tweener
     ( m.get_width(), end.get_width(), d,
-      boost::bind( &mark_placement::set_width, &m, _1 ),
+      boost::bind( &mark_placement::set_width, &m, boost::placeholders::_1 ),
       m.get_width_easing().to_claw_easing_function() ) );
   m_tweeners.insert
   ( claw::tween::single_tweener
     ( m.get_height(), end.get_height(), d,
-      boost::bind( &mark_placement::set_height, &m, _1 ),
+      boost::bind( &mark_placement::set_height, &m, boost::placeholders::_1 ),
       m.get_height_easing().to_claw_easing_function() ) );
 } // model_snapshot_tweener::insert_tweener()

--- a/bear-factory/model-editor/src/bf/history/code/action_modify_placement.cpp
+++ b/bear-factory/model-editor/src/bf/history/code/action_modify_placement.cpp
@@ -29,8 +29,8 @@ bf::make_action_modify_placement_x( snapshot* s, const mark* m, double value )
 {
   return new action_modify_placement<double>
     ( s, m,
-      boost::bind( &mark_placement::set_x_position, _1, _2 ),
-      boost::bind( &mark_placement::get_x_position, _1 ),
+      boost::bind( &mark_placement::set_x_position, boost::placeholders::_1, boost::placeholders::_2 ),
+      boost::bind( &mark_placement::get_x_position, boost::placeholders::_1 ),
       value );
 } // make_action_modify_placement_x()
 
@@ -46,8 +46,8 @@ bf::make_action_modify_placement_y( snapshot* s, const mark* m, double value )
 {
   return new action_modify_placement<double>
     ( s, m,
-      boost::bind( &mark_placement::set_y_position, _1, _2 ),
-      boost::bind( &mark_placement::get_y_position, _1 ),
+      boost::bind( &mark_placement::set_y_position, boost::placeholders::_1, boost::placeholders::_2 ),
+      boost::bind( &mark_placement::get_y_position, boost::placeholders::_1 ),
       value );
 } // make_action_modify_placement_y()
 
@@ -64,8 +64,8 @@ bf::make_action_modify_placement_angle
 {
   return new action_modify_placement<double>
     ( s, m,
-      boost::bind( &mark_placement::set_angle, _1, _2 ),
-      boost::bind( &mark_placement::get_angle, _1 ),
+      boost::bind( &mark_placement::set_angle, boost::placeholders::_1, boost::placeholders::_2 ),
+      boost::bind( &mark_placement::get_angle, boost::placeholders::_1 ),
       value );
 } // make_action_modify_placement_angle()
 
@@ -82,8 +82,8 @@ bf::make_action_modify_placement_depth
 {
   return new action_modify_placement<int>
     ( s, m,
-      boost::bind( &mark_placement::set_depth_position, _1, _2 ),
-      boost::bind( &mark_placement::get_depth_position, _1 ),
+      boost::bind( &mark_placement::set_depth_position, boost::placeholders::_1, boost::placeholders::_2 ),
+      boost::bind( &mark_placement::get_depth_position, boost::placeholders::_1 ),
       value );
 } // make_action_modify_placement_depth()
 
@@ -100,8 +100,8 @@ bf::make_action_modify_placement_visibility
 {
   return new action_modify_placement<bool>
     ( s, m,
-      boost::bind( &mark_placement::set_visibility, _1, _2 ),
-      boost::bind( &mark_placement::is_visible, _1 ),
+      boost::bind( &mark_placement::set_visibility, boost::placeholders::_1, boost::placeholders::_2 ),
+      boost::bind( &mark_placement::is_visible, boost::placeholders::_1 ),
       value );
 } // make_action_modify_placement_visibility()
 
@@ -118,8 +118,8 @@ bf::make_action_modify_placement_width
 {
   return new action_modify_placement<double>
     ( s, m,
-      boost::bind( &mark_placement::set_width, _1, _2 ),
-      boost::bind( &mark_placement::get_width, _1 ),
+      boost::bind( &mark_placement::set_width, boost::placeholders::_1, boost::placeholders::_2 ),
+      boost::bind( &mark_placement::get_width, boost::placeholders::_1 ),
       value );
 } // make_action_modify_placement_width()
 
@@ -136,7 +136,7 @@ bf::make_action_modify_placement_height
 {
   return new action_modify_placement<double>
     ( s, m,
-      boost::bind( &mark_placement::set_height, _1, _2 ),
-      boost::bind( &mark_placement::get_height, _1 ),
+      boost::bind( &mark_placement::set_height, boost::placeholders::_1, boost::placeholders::_2 ),
+      boost::bind( &mark_placement::get_height, boost::placeholders::_1 ),
       value );
 } // make_action_modify_placement_height()


### PR DESCRIPTION
This fixes compilation problems when building against boost 1.74 where
placeholders are no longer imported into the global namespace by
default.